### PR TITLE
Use ursa#master.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jsonld": "^1.0.1",
     "jsonld-signatures": "^2.2.1",
     "node-forge": "^0.7.4",
-    "ursa": "^0.9.4",
+    "ursa": "github:JoshKaufman/ursa#7083023efe0dd3802573c4cdbe8b4916708a5a51",
     "uuid": "3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Ursa 0.9.4 (the current release) does not build on node 10.x.  This has been fixed on master but it is unclear when we will see a release.

https://github.com/JoshKaufman/ursa/issues/172