### PR TITLE
did-io driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.0.0 - TBD
 
 ### Changed
+- **BREAKING**: Uses `v1.driver(options)` API instead of `v1.veres()`
 - **BREAKING**: Use crypto-ld@3. crypto-ld@3 produces key fingerprints that
   have a different encoding from crypto-ld@2.
 - **BREAKING**: Remove unnecessary `generateKeyObject` API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 4.0.0 - TBD
 
 ### Changed
-- **BREAKING**: Uses `v1.driver(options)` API instead of `v1.veres()`
+- **BREAKING**: Uses `v1.driver(options)` API instead of `v1.veres()`.
 - **BREAKING**: Use crypto-ld@3. crypto-ld@3 produces key fingerprints that
   have a different encoding from crypto-ld@2.
 - **BREAKING**: Remove unnecessary `generateKeyObject` API.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Veres One DIDs
 
 This library provides support classes for creating and processing
-Decentralized Identifiers for Veres One. This library enables a developer to:
+Decentralized Identifiers for [Veres One](https://veres.one/). This library
+enables a developer to:
 
 * Create a Veres One DID
 * Generate Veres One cryptographic proofs
@@ -22,19 +23,20 @@ const veresDriver = v1.driver(options);
 
 * options - a set of options used when generating the DID Document
   * didType - the type of DID to generate.
-      Options: 'nym' or 'uuid' (default: 'nym')
+      Options: 'nym' (default) or 'uuid'
   * `invokeKey` - optionally pass in a Capability Invocation key, otherwise
     it will be generated.
   * keyType - the type of keys to generate.
-      Options: 'RsaVerificationKey2018' (default: 'RsaVerificationKey2018').
+      Options: 'Ed25519VerificationKey2018' (default) or
+      'RsaVerificationKey2018'
   * hostname - ledger node hostname override
   * passphrase - the passphrase to use to encrypt the private keys for
       nym-based DIDs. Set to `null` if the private keys should not be encrypted.
   * mode - the mode/environment to generate the DID in.
-      Options: 'dev', 'test', 'live' (default: 'dev').
+      Options: 'dev' (default), 'test', 'live'
 
-If you do not specify a particular ledger hostname, one will be determined
-based on the `mode` parameter (either 'test', 'dev' or 'live').
+If you do not specify a particular ledger hostname, one will be automatically
+selected based on the `mode` parameter (either 'test', 'dev' or 'live').
 
 If you want to connect to a specific hostname (for testing a particular node,
 for example), you can specify the override directly:
@@ -51,53 +53,33 @@ resolved Promise.
 
 ```js
 // Generate a new DID Document
-veresDriver
-  .generate({didType: 'nym', keyType: 'Ed25519VerificationKey2018'}) // default
-  .then(didDocument => {
-    // A new didDocument is generated. Log it to console
-    console.log('Generated:', JSON.stringify(didDocument, null, 2));
-    return didDocument;
-  })
+const didDocument = await veresDriver.generate(
+  {didType: 'nym', keyType: 'Ed25519VerificationKey2018'}); // default
 
-  // Now register the newly generated DID Document
-  .then(didDocument => veresDriver.register({ didDocument }))
+// Log the new didDocument to the console.
+console.log('Generated:', JSON.stringify(didDocument, null, 2));
 
-  // Log the results
-  .then(registrationResult => {
-    // Log the result of registering the didDoc to the VeresOne Test ledger
-    console.log('Registered!', JSON.stringify(registrationResult, null, 2));
-  })
-  .catch(console.error);
+// Now register the newly generated DID Document
+const registrationResult = await veresDriver.register({didDocument});
+
+// Log the result of registering the didDoc to the VeresOne Test ledger
+console.log('Registered!', JSON.stringify(registrationResult, null, 2));
 ```
 
 #### Registering a (newly generated) DID Document
 
-To register a DID Document using an Equihash proof of work:
+To register a DID Document:
 
 ```js
-veresDriver.register({ didDocument }).then().catch();
-```
-
-To register using an Accelerator:
-
-```js
-const accelerator = 'genesis.testnet.veres.one';
-const authDoc = didDocumentFromAccelerator; // obtained previously
-
-veresDriver.register({ didDocument, accelerator, authDoc })
-  .then(result => result.text())
-  .then(text => console.log(JSON.stringify(text, null, 2)))
-  .catch(console.error);
+const registrationResult = await veresDriver.register({didDocument});
 ```
 
 #### `get()` - Retrieving a Veres One DID Document
 
 ```js
 const did = 'did:v1:test:nym:ApvL3PKAzQvFnRVqyZKhSYD2i8XcsLG1Dy4FrSdEKAdR';
-
-veresDriver.get({ did })
-  .then(didDoc => { console.log(JSON.stringify(didDoc, null, 2)); })
-  .catch(console.error);
+const didDoc = await veresDriver.get({did});
+console.log(JSON.stringify(didDoc, null, 2));
 ```
 
 ### Attach an ocap-ld delegation proof to a capability DID Document

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ const veresDriver = v1.driver(options);
 * options - a set of options used when generating the DID Document
   * didType - the type of DID to generate.
       Options: 'nym' or 'uuid' (default: 'nym')
+  * `invokeKey` - optionally pass in a Capability Invocation key, otherwise
+    it will be generated.
   * keyType - the type of keys to generate.
       Options: 'RsaVerificationKey2018' (default: 'RsaVerificationKey2018').
   * hostname - ledger node hostname override
@@ -70,11 +72,6 @@ veresDriver
   })
   .catch(console.error);
 ```
-
-Note: This also saves the generated private/public key pairs, a local copy of
-the document, as well as any metadata, in the local (typically on-disk) store.
-See [Setting Up Storage](#setting-up-storage) for more detail.
-
 
 #### Registering a (newly generated) DID Document
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ resolved Promise.
 #### Generating and Registering a Veres One DID Document
 
 ```js
-// Generate a new DID Document, store the private keys locally
+// Generate a new DID Document
 veresDriver
   .generate({didType: 'nym', keyType: 'Ed25519VerificationKey2018'}) // default
   .then(didDocument => {
@@ -85,7 +85,8 @@ const accelerator = 'genesis.testnet.veres.one';
 const authDoc = didDocumentFromAccelerator; // obtained previously
 
 veresDriver.register({ didDocument, accelerator, authDoc })
-  .then(result => console.log(JSON.stringify(await result.text(), null, 2)))
+  .then(result => result.text())
+  .then(text => console.log(JSON.stringify(text, null, 2)))
   .catch(console.error);
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ const v1 = require('did-veres-one');
 // See Configuration below for list of options
 const options = {mode: 'dev', httpsAgent, hostname: 'localhost:12345'};
 const veresDriver = v1.driver(options);
-
-// this can now be used with did-io, or directly
 ```
 
 ## Configuration
@@ -62,7 +60,6 @@ veresDriver
   })
 
   // Now register the newly generated DID Document
-  // Use Equihash Proof of Work by default (see below)
   .then(didDocument => veresDriver.register({ didDocument }))
 
   // Log the results

--- a/lib/VeresOne.js
+++ b/lib/VeresOne.js
@@ -7,11 +7,8 @@ const constants = require('./constants');
 const documentLoader = require('./documentLoader');
 const veresOneContext = require('veres-one-context');
 const VeresOneDidDoc = require('./VeresOneDidDoc');
-const {LDKeyPair} = require('crypto-ld');
 const VeresOneClient = require('./VeresOneClient');
-const VeresOneClientError = require('./VeresOneClientError');
 
-const jsonld = require('jsonld');
 const jsigs = require('jsonld-signatures');
 
 class VeresOne {

--- a/lib/VeresOne.js
+++ b/lib/VeresOne.js
@@ -166,15 +166,17 @@ class VeresOne {
    * @param [mode] {string} Defaults to the driver's mode
    * @param [invokeKey] {LDKeyPair} Optional invocation key to serve as the DID
    *   basis (useful if you've generated a key via a KMS).
+   * @param [authKey] {LDKeyPair}
+   * @param [delegateKey] {LDKeyPair}
    *
    * @throws {Error}
    *
    * @returns {Promise<VeresOneDidDoc>}
    */
   async generate({didType = 'nym', keyType = constants.DEFAULT_KEY_TYPE,
-    passphrase = null, mode = this.mode, invokeKey} = {}) {
+    passphrase = null, mode = this.mode, invokeKey, authKey, delegateKey} = {}) {
     return VeresOneDidDoc.generate({
-      didType, keyType, passphrase, mode, invokeKey
+      didType, keyType, passphrase, mode, invokeKey, authKey, delegateKey
     });
   }
 

--- a/lib/VeresOne.js
+++ b/lib/VeresOne.js
@@ -160,16 +160,22 @@ class VeresOne {
   /**
    * Generates a new DID Document with relevant keys, saves keys in key store.
    *
-   * @param options
-   * @param [options.didType='nym'] {string} DID type, 'nym' or 'uuid'
+   * @param [didType='nym'] {string} DID type, 'nym' or 'uuid'
+   * @param [keyType] {string}
+   * @param [passphrase] {string}
+   * @param [mode] {string} Defaults to the driver's mode
+   * @param [invokeKey] {LDKeyPair} Optional invocation key to serve as the DID
+   *   basis (useful if you've generated a key via a KMS).
    *
    * @throws {Error}
    *
    * @returns {Promise<VeresOneDidDoc>}
    */
   async generate({didType = 'nym', keyType = constants.DEFAULT_KEY_TYPE,
-    passphrase = null, mode = this.mode} = {}) {
-    return VeresOneDidDoc.generate({didType, keyType, passphrase, mode});
+    passphrase = null, mode = this.mode, invokeKey} = {}) {
+    return VeresOneDidDoc.generate({
+      didType, keyType, passphrase, mode, invokeKey
+    });
   }
 
   /**

--- a/lib/VeresOneDidDoc.js
+++ b/lib/VeresOneDidDoc.js
@@ -37,6 +37,9 @@ class VeresOneDidDoc {
    * @param [options.didType='nym'] {string} DID type, 'nym' or 'uuid'
    * @param [options.mode] {string} 'dev'/'live' etc.
    *
+   * Optionally pass in an invocation key to use to generate the DID:
+   * @param [options.invokeKey] {LDKeyPair}
+   *
    * Params needed for key generation:
    * @param [options.keyType] {string}
    * @param [options.passphrase] {string}

--- a/lib/VeresOneDidDoc.js
+++ b/lib/VeresOneDidDoc.js
@@ -76,11 +76,14 @@ class VeresOneDidDoc {
    * @param [keyType] {string}
    * @param [didType] {string}
    * @param [invokeKey] {LDKeyPair}
+   * @param [authKey] {LDKeyPair}
+   * @param [delegateKey] {LDKeyPair}
    *
    * @returns {Promise}
    */
   async init({
-    mode, passphrase, didType, keyType = constants.DEFAULT_KEY_TYPE, invokeKey
+    mode, passphrase, didType, keyType = constants.DEFAULT_KEY_TYPE, invokeKey,
+    authKey, delegateKey
   }) {
     const keyOptions = {type: keyType, passphrase};
 
@@ -97,13 +100,17 @@ class VeresOneDidDoc {
     keyOptions.controller = did;
 
     // Generate an authentication key pair and proof purpose node
-    const authKey = await LDKeyPair.generate(keyOptions);
+    if(!authKey) {
+      authKey = await LDKeyPair.generate(keyOptions);
+    }
     authKey.id = this.generateKeyId({did, keyPair: authKey});
     this.doc[constants.PROOF_PURPOSES.authentication] = [authKey.publicNode()];
     this.keys[authKey.id] = authKey;
 
     // Generate a capabilityDelegation key pair and proof purpose node
-    const delegateKey = await LDKeyPair.generate(keyOptions);
+    if(!delegateKey) {
+      delegateKey = await LDKeyPair.generate(keyOptions);
+    }
     delegateKey.id = this.generateKeyId({did, keyPair: delegateKey});
     this.doc[constants.PROOF_PURPOSES.capabilityDelegation] =
       [delegateKey.publicNode()];

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ module.exports = {
   constants,
   documentLoader,
   VeresOne,
-  veres: options => {
+  driver: options => {
     return new VeresOne(options);
   },
   VeresOneClient: require('./VeresOneClient'),


### PR DESCRIPTION
- Replace constructor API from `v1.veres()` to `v1.driver()`, to match the new [`did-io` API](https://github.com/digitalbazaar/did-io/pull/44).
- Expand README documentation