### PR TITLE
Add assertionMethod proof purpose to generated DID Document

### DIFF
--- a/lib/VeresOne.js
+++ b/lib/VeresOne.js
@@ -165,8 +165,9 @@ class VeresOne {
    * @param [mode] {string} Defaults to the driver's mode
    * @param [invokeKey] {LDKeyPair} Optional invocation key to serve as the DID
    *   basis (useful if you've generated a key via a KMS).
-   * @param [authKey] {LDKeyPair}
-   * @param [delegateKey] {LDKeyPair}
+   * @param [authKey] {LDKeyPair} Optional
+   * @param [delegateKey] {LDKeyPair} Optional
+   * @param [assertionKey] {LDKeyPair} Optional 
    *
    * @throws {Error}
    *
@@ -174,10 +175,12 @@ class VeresOne {
    */
   async generate({
     didType = 'nym', keyType = constants.DEFAULT_KEY_TYPE,
-    passphrase = null, mode = this.mode, invokeKey, authKey, delegateKey
+    passphrase = null, mode = this.mode, invokeKey, authKey, delegateKey,
+    assertionKey
   } = {}) {
     return VeresOneDidDoc.generate({
-      didType, keyType, passphrase, mode, invokeKey, authKey, delegateKey
+      didType, keyType, passphrase, mode, invokeKey, authKey, delegateKey, 
+      assertionKey
     });
   }
 

--- a/lib/VeresOneDidDoc.js
+++ b/lib/VeresOneDidDoc.js
@@ -83,15 +83,26 @@ class VeresOneDidDoc {
    */
   async init({
     mode, passphrase, didType, keyType = constants.DEFAULT_KEY_TYPE, invokeKey,
-    authKey, delegateKey
+    authKey, delegateKey, assertionKey
   }) {
     const keyOptions = {type: keyType, passphrase};
 
-    // Generate a capabilityInvocation key, to base the DID URI on
+    // Generate a capabilityInvocation key pair and proof purpose node
     if(!invokeKey) {
       invokeKey = await LDKeyPair.generate(keyOptions);
     }
 
+    // Generate a capabilityDelegation key pair and proof purpose node
+    if(!delegateKey) {
+      delegateKey = await LDKeyPair.generate(keyOptions);
+    }
+
+    // Generate an assertionMethod key pair and proof purpose node
+    if(!assertionKey) {
+      assertionKey = await LDKeyPair.generate(keyOptions);
+    }
+
+    // Use the generated capabilityInvocation key to base the DID URI on
     const did = this.generateId({keyPair: invokeKey, didType, mode});
     this.doc.id = did;
 
@@ -107,10 +118,8 @@ class VeresOneDidDoc {
     this.doc[constants.PROOF_PURPOSES.authentication] = [authKey.publicNode()];
     this.keys[authKey.id] = authKey;
 
-    // Generate a capabilityDelegation key pair and proof purpose node
-    if(!delegateKey) {
-      delegateKey = await LDKeyPair.generate(keyOptions);
-    }
+    // Generate a capabilityDelegation purpose node using the previously
+    // generated key
     delegateKey.id = this.generateKeyId({did, keyPair: delegateKey});
     this.doc[constants.PROOF_PURPOSES.capabilityDelegation] =
       [delegateKey.publicNode()];
@@ -122,6 +131,13 @@ class VeresOneDidDoc {
     this.doc[constants.PROOF_PURPOSES.capabilityInvocation] =
       [invokeKey.publicNode()];
     this.keys[invokeKey.id] = invokeKey;
+
+    // Generate an assertionMethod purpose node using the previously
+    // generated key
+    assertionKey.id = this.generateKeyId({did, keyPair: invokeKey});
+    this.doc[constants.PROOF_PURPOSES.assertionMethod] =
+      [assertionKey.publicNode()];
+    this.keys[assertionKey.id] = assertionKey;
   }
 
   /**
@@ -524,8 +540,10 @@ class VeresOneDidDoc {
   removeKey(key) {
     // check all proof purpose keys
     for(const proofPurposeType of Object.values(constants.PROOF_PURPOSES)) {
-      this.doc[proofPurposeType] = this.doc[proofPurposeType]
-        .filter(k => k.id !== key.id);
+      if (this.doc[proofPurposeType]) {
+        this.doc[proofPurposeType] = this.doc[proofPurposeType]
+          .filter(k => k.id !== key.id);
+      }
     }
 
     // also remove key from this doc's keys hash

--- a/lib/VeresOneDidDoc.js
+++ b/lib/VeresOneDidDoc.js
@@ -87,17 +87,22 @@ class VeresOneDidDoc {
   }) {
     const keyOptions = {type: keyType, passphrase};
 
-    // Generate a capabilityInvocation key pair and proof purpose node
+    // Generate an authentication key pair
+    if(!authKey) {
+      authKey = await LDKeyPair.generate(keyOptions);
+    }
+
+    // Generate a capabilityInvocation key pair
     if(!invokeKey) {
       invokeKey = await LDKeyPair.generate(keyOptions);
     }
 
-    // Generate a capabilityDelegation key pair and proof purpose node
+    // Generate a capabilityDelegation key pair
     if(!delegateKey) {
       delegateKey = await LDKeyPair.generate(keyOptions);
     }
 
-    // Generate an assertionMethod key pair and proof purpose node
+    // Generate an assertionMethod key pair
     if(!assertionKey) {
       assertionKey = await LDKeyPair.generate(keyOptions);
     }
@@ -106,35 +111,31 @@ class VeresOneDidDoc {
     const did = this.generateId({keyPair: invokeKey, didType, mode});
     this.doc.id = did;
 
-    // assign the DID as the controller for the keys
+    // Assign the DID as the controller for the keys
     invokeKey.controller = did;
     keyOptions.controller = did;
 
-    // Generate an authentication key pair and proof purpose node
-    if(!authKey) {
-      authKey = await LDKeyPair.generate(keyOptions);
-    }
+    // Generate an authentication proof purpose node
     authKey.id = this.generateKeyId({did, keyPair: authKey});
-    this.doc[constants.PROOF_PURPOSES.authentication] = [authKey.publicNode()];
+    this.doc[constants.PROOF_PURPOSES.authentication] = 
+      [authKey.publicNode()];
     this.keys[authKey.id] = authKey;
 
-    // Generate a capabilityDelegation purpose node using the previously
-    // generated key
-    delegateKey.id = this.generateKeyId({did, keyPair: delegateKey});
-    this.doc[constants.PROOF_PURPOSES.capabilityDelegation] =
-      [delegateKey.publicNode()];
-    this.keys[delegateKey.id] = delegateKey;
-
-    // Generate a capabilityInvocation purpose node using the previously
-    // generated key
+    // Generate a capabilityInvocation proof purpose node
     invokeKey.id = this.generateKeyId({did, keyPair: invokeKey});
     this.doc[constants.PROOF_PURPOSES.capabilityInvocation] =
       [invokeKey.publicNode()];
     this.keys[invokeKey.id] = invokeKey;
 
-    // Generate an assertionMethod purpose node using the previously
-    // generated key
-    assertionKey.id = this.generateKeyId({did, keyPair: invokeKey});
+    // Generate a capabilityDelegation proof purpose node
+    delegateKey.id = this.generateKeyId({did, keyPair: delegateKey});
+    this.doc[constants.PROOF_PURPOSES.capabilityDelegation] =
+      [delegateKey.publicNode()];
+    this.keys[delegateKey.id] = delegateKey;
+
+    
+    // Generate an assertionMethod purpose node
+    assertionKey.id = this.generateKeyId({did, keyPair: assertionKey});
     this.doc[constants.PROOF_PURPOSES.assertionMethod] =
       [assertionKey.publicNode()];
     this.keys[assertionKey.id] = assertionKey;

--- a/lib/VeresOneDidDoc.js
+++ b/lib/VeresOneDidDoc.js
@@ -39,6 +39,9 @@ class VeresOneDidDoc {
    *
    * Optionally pass in an invocation key to use to generate the DID:
    * @param [options.invokeKey] {LDKeyPair}
+   * @param [options.authKey] {LDKeyPair}
+   * @param [options.delegateKey] {LDKeyPair}
+   * @param [options.assertionKey] {LDKeyPair}
    *
    * Params needed for key generation:
    * @param [options.keyType] {string}
@@ -78,6 +81,7 @@ class VeresOneDidDoc {
    * @param [invokeKey] {LDKeyPair}
    * @param [authKey] {LDKeyPair}
    * @param [delegateKey] {LDKeyPair}
+   * @param [assertionKey] {LDKeyPair}
    *
    * @returns {Promise}
    */

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,6 +20,7 @@ module.exports = {
   PROOF_PURPOSES: {
     authentication: 'authentication',
     capabilityDelegation: 'capabilityDelegation',
-    capabilityInvocation: 'capabilityInvocation'
+    capabilityInvocation: 'capabilityInvocation',
+    assertionMethod: 'assertionMethod'
   }
 };

--- a/tests/VeresOneDidDoc.spec.js
+++ b/tests/VeresOneDidDoc.spec.js
@@ -222,7 +222,7 @@ describe('VeresOneDidDoc', () => {
       await didDoc.init({mode: 'test', passphrase: null});
 
       const keys = await didDoc.exportKeys();
-      expect(Object.keys(keys).length).to.equal(3);
+      expect(Object.keys(keys).length).to.equal(4);
       for(const k in keys) {
         expect(keys[k]).to.have.property('privateKeyBase58');
       }

--- a/tests/VeresOneDidDoc.spec.js
+++ b/tests/VeresOneDidDoc.spec.js
@@ -54,6 +54,7 @@ describe('VeresOneDidDoc', () => {
       expect(didDoc.doc.authentication.length).to.equal(1);
       expect(didDoc.doc.capabilityDelegation.length).to.equal(1);
       expect(didDoc.doc.capabilityInvocation.length).to.equal(1);
+      expect(didDoc.doc.assertionMethod.length).to.equal(1);
     });
 
     it('should generate an invoke key', async () => {

--- a/tests/dids/did-v1-test-nym-eddsa-example-keys.json
+++ b/tests/dids/did-v1-test-nym-eddsa-example-keys.json
@@ -16,5 +16,11 @@
     "type": "Ed25519VerificationKey2018",
     "publicKeyBase58": "EsP4zycDtPDT2K6YDnu2LS1hWFsyZDyLXrH6xkGkaW5s",
     "privateKeyBase58": "3FJEu99xHKrx5gdReAWfrponxSY9Tst6cMYyrBXCS6eGueo8m7h3u2Y5hqJd2iWfHyeAayV8VXcxGGrYBUxAKrUd"
+  },
+  "did:v1:test:nym:z279wbVAtyvuhWzM8CyMScPvS2G7RmkvGrBX5jf3MDmzmow3#assertion-1": {
+    "id": "did:v1:test:nym:z279wbVAtyvuhWzM8CyMScPvS2G7RmkvGrBX5jf3MDmzmow3#assertion-1",
+    "type": "Ed25519VerificationKey2018",
+    "publicKeyBase58": "EsP4zycDtPDT2K6YDnu2LS1hWFsyZDyLXrH6xkGkaW5s",
+    "privateKeyBase58": "3FJEu99xHKrx5gdReAWfrponxSY9Tst6cMYyrBXCS6eGueo8m7h3u2Y5hqJd2iWfHyeAayV8VXcxGGrYBUxAKrUd"
   }
 }

--- a/tests/dids/did-v1-test-nym-eddsa-example.json
+++ b/tests/dids/did-v1-test-nym-eddsa-example.json
@@ -24,5 +24,13 @@
       "controller": "did:v1:test:nym:z279wbVAtyvuhWzM8CyMScPvS2G7RmkvGrBX5jf3MDmzmow3",
       "publicKeyBase58": "EsP4zycDtPDT2K6YDnu2LS1hWFsyZDyLXrH6xkGkaW5s"
     }
+  ],
+  "assertionMethod": [
+    {
+      "id": "did:v1:test:nym:z279wbVAtyvuhWzM8CyMScPvS2G7RmkvGrBX5jf3MDmzmow3#assertion-1",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:v1:test:nym:z279wbVAtyvuhWzM8CyMScPvS2G7RmkvGrBX5jf3MDmzmow3",
+      "publicKeyBase58": "EsP4zycDtPDT2K6YDnu2LS1hWFsyZDyLXrH6xkGkaW5s"
+    }
   ]
 }


### PR DESCRIPTION
This PR adds support for generating a v1 DID with a key authorised for the `assertionMethod` proof purpose, required for signing VC's. Which partially resolves #36, I did not add support for key agreement as this will require a different type of key suitable for DH such as Curve25519/X25519.