### PR TITLE
Add setKeyId() and methodId to did:v1 driver.

### DIFF
--- a/lib/VeresOne.js
+++ b/lib/VeresOne.js
@@ -24,7 +24,7 @@ class VeresOne {
    * @param [options.client] {WebLedgerClient}
    */
   constructor(options = {}) {
-    this.ledger = 'veres';
+    this.methodId = 'v1';
     this.mode = options.mode || constants.DEFAULT_MODE;
 
     this.logger = options.logger || console;
@@ -114,6 +114,24 @@ class VeresOne {
   }
 
   /**
+   * Sets the id of a given key. Used by `did-io` drivers.
+   *
+   * @param {LDKeyPair} key
+   * @param {string} [did] - Optional DID.
+   * @param {string} [didType] - 'nym' or 'uuid'
+   * @param {string} [mode] - 'test', 'dev', 'live' etc.
+   *
+   * @returns {string} Returns the key's id.
+   */
+  setKeyId({key, did, didType = constants.DEFAULT_DID_TYPE, mode = this.mode}) {
+    if(!did) {
+      did = VeresOneDidDoc.generateDid({key, didType, mode});
+    }
+    key.id = VeresOneDidDoc.generateKeyId({did, keyPair: key});
+    return key.id;
+  }
+
+  /**
    * Fetches a DID Document for a given DID. First checks the ledger, and if
    * not found, also checks local DID storage (for pairwise DIDs).
    *
@@ -173,7 +191,7 @@ class VeresOne {
    * @returns {Promise<VeresOneDidDoc>}
    */
   async generate({
-    didType = 'nym', keyType = constants.DEFAULT_KEY_TYPE,
+    didType = constants.DEFAULT_DID_TYPE, keyType = constants.DEFAULT_KEY_TYPE,
     passphrase = null, mode = this.mode, invokeKey, authKey, delegateKey,
     assertionKey
   } = {}) {

--- a/lib/VeresOne.js
+++ b/lib/VeresOne.js
@@ -114,21 +114,22 @@ class VeresOne {
   }
 
   /**
-   * Sets the id of a given key. Used by `did-io` drivers.
+   * Generates and returns the id of a given key. Used by `did-io` drivers.
    *
    * @param {LDKeyPair} key
    * @param {string} [did] - Optional DID.
    * @param {string} [didType] - 'nym' or 'uuid'
    * @param {string} [mode] - 'test', 'dev', 'live' etc.
    *
-   * @returns {string} Returns the key's id.
+   * @returns {Promise<string>} Returns the key's id. (Async to match the
+   *   `did-io` api signature.)
    */
-  setKeyId({key, did, didType = constants.DEFAULT_DID_TYPE, mode = this.mode}) {
+  async computeKeyId({
+    key, did, didType = constants.DEFAULT_DID_TYPE, mode = this.mode}) {
     if(!did) {
       did = VeresOneDidDoc.generateDid({key, didType, mode});
     }
-    key.id = VeresOneDidDoc.generateKeyId({did, keyPair: key});
-    return key.id;
+    return VeresOneDidDoc.generateKeyId({did, keyPair: key});
   }
 
   /**

--- a/lib/VeresOne.js
+++ b/lib/VeresOne.js
@@ -24,7 +24,7 @@ class VeresOne {
    * @param [options.client] {WebLedgerClient}
    */
   constructor(options = {}) {
-    this.methodId = 'v1';
+    this.method = 'v1';
     this.mode = options.mode || constants.DEFAULT_MODE;
 
     this.logger = options.logger || console;

--- a/lib/VeresOneDidDoc.js
+++ b/lib/VeresOneDidDoc.js
@@ -91,6 +91,48 @@ class VeresOneDidDoc {
   }
 
   /**
+   * Generates a DID uri, either as a globally unique random string (uuid),
+   * or from a given key pair (in case of cryptonym type did).
+   *
+   * @param [key] {LDKeyPair} - Required for generating a cryptonym DID.
+   * @param [didType='nym'] {string} 'uuid' or 'nym'. If 'nym', a key pair
+   *   must also be passed in (to generate the did uri from).
+   * @param [mode='dev'] {string}
+   *
+   * @returns {string} DID uri
+   */
+  static generateDid({
+    key, didType = constants.DEFAULT_DID_TYPE, mode = constants.DEFAULT_MODE}) {
+    if(didType === 'uuid') {
+      const prefix = (mode === 'test') ? 'did:v1:test:' : 'did:v1:';
+      return (prefix + 'uuid:' + uuid()).replace(/-/g, '');
+    }
+
+    // didType === 'nym'
+    if(!key) {
+      throw new TypeError('`key` is required to generate cryptonym DID.');
+    }
+
+    return VeresOneDidDoc.createCryptonymDid({key, mode});
+  }
+
+  static generateKeyId({did, keyPair}) {
+    return `${did}#${keyPair.fingerprint()}`;
+  }
+
+  /**
+   * Creates a cryptonym DID from a given key pair.
+   *
+   * @param key {LDKeyPair}
+   * @param [mode='dev'] {string}
+   */
+  static createCryptonymDid({key, mode = constants.DEFAULT_MODE}) {
+    const prefix = (mode === 'test') ? 'did:v1:test' : 'did:v1';
+
+    return `${prefix}:nym:${key.fingerprint()}`;
+  }
+
+  /**
    * Returns the DID uri.
    */
   get id() {
@@ -125,7 +167,7 @@ class VeresOneDidDoc {
     }
 
     // Use the generated capabilityInvocation key to base the DID URI on
-    const did = this.generateId({keyPair: invokeKey, didType, mode});
+    const did = VeresOneDidDoc.generateDid({key: invokeKey, didType, mode});
     this.doc.id = did;
 
     // Assign the DID as a default controller for the keys
@@ -151,7 +193,7 @@ class VeresOneDidDoc {
     for(const keyPair of [authKey, invokeKey, delegateKey, assertionKey]) {
       keyPair.controller = did;
       if(!keyPair.id) {
-        keyPair.id = this.generateKeyId({did, keyPair});
+        keyPair.id = VeresOneDidDoc.generateKeyId({did, keyPair});
       }
     }
 
@@ -174,35 +216,6 @@ class VeresOneDidDoc {
     this.doc[constants.PROOF_PURPOSES.assertionMethod] =
       [assertionKey.publicNode()];
     this.keys[assertionKey.id] = assertionKey;
-  }
-
-  /**
-   * Generates a DID uri, either as a globally unique random string (uuid),
-   * or from a given key pair (in case of cryptonym type did).
-   *
-   * @param [keyPair] {LDKeyPair}
-   * @param [didType='nym'] {string} 'uuid' or 'nym'. If 'nym', a key pair
-   *   must also be passed in (to generate the did uri from).
-   * @param [mode='dev'] {string}
-   *
-   * @returns {string} DID uri
-   */
-  generateId({keyPair, didType = 'nym', mode = constants.DEFAULT_MODE}) {
-    if(didType === 'uuid') {
-      const prefix = (mode === 'test') ? 'did:v1:test:' : 'did:v1:';
-      return (prefix + 'uuid:' + uuid()).replace(/-/g, '');
-    }
-
-    if(!keyPair) {
-      throw new TypeError('`keyPair` is required.');
-    }
-
-    // didType === 'nym'
-    return this.createCryptonymDid({keyPair, mode});
-  }
-
-  generateKeyId({did, keyPair}) {
-    return `${did}#${keyPair.fingerprint()}`;
   }
 
   /**
@@ -314,18 +327,6 @@ class VeresOneDidDoc {
       }
     }
     return {};
-  }
-
-  /**
-   * Creates a cryptonym DID from a given key pair.
-   *
-   * @param keyPair {LDKeyPair}
-   * @param [mode='dev'] {string}
-   */
-  createCryptonymDid({keyPair, mode = constants.DEFAULT_MODE}) {
-    const prefix = (mode === 'test') ? 'did:v1:test' : 'did:v1';
-
-    return `${prefix}:nym:${keyPair.fingerprint()}`;
   }
 
   /**
@@ -696,7 +697,7 @@ class VeresOneDidDoc {
 
     // Generate an add a new key to the same proof purpose (key id not re-used)
     const newKey = await LDKeyPair.generate({type: keyType, passphrase});
-    newKey.id = this.generateKeyId({did: this.id, keyPair: newKey});
+    newKey.id = VeresOneDidDoc.generateKeyId({did: this.id, keyPair: newKey});
     newKey.controller = controller;
 
     this.addKey({key: newKey, proofPurpose, controller});

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -16,6 +16,7 @@ module.exports = {
   DID_CONTEXT_URL: didContext.constants.DID_CONTEXT_URL,
   DEFAULT_KEY_TYPE: 'Ed25519VerificationKey2018',
   DEFAULT_MODE: 'dev',
+  DEFAULT_DID_TYPE: 'nym', // vs. 'uuid'
   SUPPORTED_KEY_TYPES: ['RsaVerificationKey2018', 'Ed25519VerificationKey2018'],
   PROOF_PURPOSES: {
     authentication: 'authentication',

--- a/package.json
+++ b/package.json
@@ -25,29 +25,29 @@
     "lint": "eslint lib tests"
   },
   "dependencies": {
-    "apisauce": "^1.0.2",
-    "base64url-universal": "^1.0.0",
+    "apisauce": "^1.1.1",
+    "base64url-universal": "^1.1.0",
     "crypto-ld": "^3.7.0",
     "did-context": "^2.0.0",
-    "fast-json-patch": "^2.1.0",
-    "http-signature-header": "^1.2.0",
+    "fast-json-patch": "^2.2.1",
+    "http-signature-header": "^1.3.1",
     "json-ld-patch-context": "^4.0.0",
-    "jsonld": "^2.0.0",
-    "jsonld-signatures": "^5.0.0",
+    "jsonld": "^3.0.1",
+    "jsonld-signatures": "^5.0.1",
     "ocapld": "^2.0.0",
-    "uuid-random": "^1.0.9",
+    "uuid-random": "^1.3.0",
     "veres-one-context": "^11.0.0",
-    "web-ledger-client": "^3.1.0",
+    "web-ledger-client": "^3.3.0",
     "web-ledger-context": "^7.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^5.16.0",
-    "eslint-config-digitalbazaar": "^2.0.0",
-    "mocha": "^6.1.4",
-    "nock": "^10.0.6",
-    "sinon": "^7.3.2",
-    "sinon-chai": "^3.3.0"
+    "eslint": "^6.8.0",
+    "eslint-config-digitalbazaar": "^2.3.0",
+    "mocha": "^7.1.1",
+    "nock": "^12.0.3",
+    "sinon": "^9.0.2",
+    "sinon-chai": "^3.5.0"
   },
   "engines": {
     "node": ">=8.3.0"

--- a/tests/VeresOne.spec.js
+++ b/tests/VeresOne.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2018-2019 Veres One Project. All rights reserved.
+ * Copyright (c) 2018-2020 Veres One Project. All rights reserved.
  */
 'use strict';
 
@@ -26,6 +26,13 @@ describe('methods/veres-one', () => {
 
   beforeEach(() => {
     v1 = new VeresOne({mode: 'test'});
+  });
+
+  describe('constructor', () => {
+    it('should set mode and methodId', () => {
+      expect(v1.mode).to.equal('test');
+      expect(v1.methodId).to.equal('v1');
+    });
   });
 
   describe('get', () => {
@@ -225,6 +232,28 @@ describe('methods/veres-one', () => {
       expect(result.valid).to.exist;
       result.valid.should.be.a('boolean');
       result.valid.should.be.true;
+    });
+  });
+
+  describe('setKeyId', () => {
+    let key;
+
+    beforeEach(() => {
+      key = {
+        fingerprint: () => '12345'
+      };
+    });
+
+    it('should generate a key id based on a did', () => {
+      v1.setKeyId({did: 'did:v1:test:uuid:abcdef', key});
+
+      expect(key.id).to.equal('did:v1:test:uuid:abcdef#12345');
+    });
+
+    it('should generate a cryptonym key id based on fingerprint', () => {
+      v1.setKeyId({key, didType: 'nym', mode: 'live'});
+
+      expect(key.id).to.equal('did:v1:nym:12345#12345');
     });
   });
 

--- a/tests/VeresOne.spec.js
+++ b/tests/VeresOne.spec.js
@@ -29,9 +29,9 @@ describe('methods/veres-one', () => {
   });
 
   describe('constructor', () => {
-    it('should set mode and methodId', () => {
+    it('should set mode and method', () => {
       expect(v1.mode).to.equal('test');
-      expect(v1.methodId).to.equal('v1');
+      expect(v1.method).to.equal('v1');
     });
   });
 

--- a/tests/VeresOne.spec.js
+++ b/tests/VeresOne.spec.js
@@ -235,7 +235,7 @@ describe('methods/veres-one', () => {
     });
   });
 
-  describe('setKeyId', () => {
+  describe('computeKeyId', () => {
     let key;
 
     beforeEach(() => {
@@ -244,14 +244,14 @@ describe('methods/veres-one', () => {
       };
     });
 
-    it('should generate a key id based on a did', () => {
-      v1.setKeyId({did: 'did:v1:test:uuid:abcdef', key});
+    it('should generate a key id based on a did', async () => {
+      key.id = await v1.computeKeyId({did: 'did:v1:test:uuid:abcdef', key});
 
       expect(key.id).to.equal('did:v1:test:uuid:abcdef#12345');
     });
 
-    it('should generate a cryptonym key id based on fingerprint', () => {
-      v1.setKeyId({key, didType: 'nym', mode: 'live'});
+    it('should generate a cryptonym key id based on fingerprint', async () => {
+      key.id = await v1.computeKeyId({key, didType: 'nym', mode: 'live'});
 
       expect(key.id).to.equal('did:v1:nym:12345#12345');
     });

--- a/tests/VeresOneDidDoc.spec.js
+++ b/tests/VeresOneDidDoc.spec.js
@@ -41,11 +41,9 @@ describe('VeresOneDidDoc', () => {
     });
 
     it('should init the did id', async () => {
-      sinon.spy(didDoc, 'generateId');
-
       await didDoc.init({mode});
 
-      expect(didDoc.generateId).to.have.been.called;
+      expect(didDoc.id.startsWith('did:v1'));
     });
 
     it('should init the authn/authz keys', async () => {
@@ -66,25 +64,24 @@ describe('VeresOneDidDoc', () => {
     });
   });
 
-  describe('generateId', () => {
+  describe('generateDid', () => {
     const keyType = 'Ed25519VerificationKey2018';
 
     it('should generate a uuid type did', async () => {
       const didType = 'uuid';
-      const didDoc = new VeresOneDidDoc({keyType, didType});
-      const did = didDoc.generateId({didType, mode: 'test'});
+      const did = VeresOneDidDoc.generateDid({didType, mode: 'test'});
 
       expect(did).to.match(/^did:v1:test:uuid:.*/);
     });
 
     it('should generate a nym type did', async () => {
-      const didDoc = new VeresOneDidDoc({keyType, didType: 'nym'});
+      const didType = 'nym';
       const keyOptions = {
         type: keyType, passphrase: null
       };
 
-      const keyPair = await LDKeyPair.generate(keyOptions);
-      const did = didDoc.generateId({keyPair, mode: 'test'});
+      const key = await LDKeyPair.generate(keyOptions);
+      const did = VeresOneDidDoc.generateDid({key, didType, mode: 'test'});
 
       expect(did).to.match(/^did:v1:test:nym:.*/);
     });


### PR DESCRIPTION
For use with `did-io` and bedrock-profile.

Companion PR to https://github.com/digitalbazaar/did-method-key-js/pull/21.