### PR TITLE
UNFINISHED Remove attachTicketServiceProof & getTicketServiceProof.

### DIFF
--- a/lib/VeresOneClient.js
+++ b/lib/VeresOneClient.js
@@ -66,33 +66,6 @@ class VeresOneClient {
     return this.ledger.getStatus();
   }
 
-  async getTicketServiceProof({operation, ticketService}) {
-    let result;
-    try {
-      result = await httpClient.post(ticketService, {
-        json: {operation}, agent: this.httpsAgent
-      });
-    } catch(e) {
-      const {response} = e;
-      // if there is no response just rethrow the error
-      if(!response) {
-        throw e;
-      }
-      const error = new VeresOneClientError(
-        'Error retrieving record.', 'NetworkError');
-      error.details = {
-        baseURL: ticketService, error: e, status: response.status, result
-      };
-      // errors in this range might contain response data
-      if(response.status > 399 && response.status < 500) {
-        // httpClient puts the error on the data object
-        error.details.error = e.data || response.data || e;
-      }
-      throw error;
-    }
-    return result.data;
-  }
-
   /**
    * Sends an operation to a Veres One accelerator.
    *

--- a/lib/VeresOneDriver.js
+++ b/lib/VeresOneDriver.js
@@ -389,7 +389,7 @@ class VeresOneDriver {
    *  1. Using an Accelerator service, in which case an authorization DID
    *     Document is required beforehand (typically obtained in exchange for
    *     payment).
-   *  2. Ticket service.
+   *  2. Ticket service (deprecated).
    *
    * @param {object} operation - WebLedger operation.
    * @param {string} operation.type - Operation type 'create', 'update' etc.

--- a/lib/attachProof.js
+++ b/lib/attachProof.js
@@ -15,7 +15,7 @@ const {ZCAP_ROOT_PREFIX} = require('./constants');
  *  1. Using an Accelerator service, in which case an authorization DID
  *     Document is required beforehand (typically obtained in exchange for
  *     payment).
- *  2. Ticket service.
+ *  2. Ticket service (deprecated).
  *
  * @param {object} operation - WebLedger operation.
  * @param {string} operation.type - Operation type 'create', 'update' etc.
@@ -52,17 +52,10 @@ async function attachProofs(operation, {
   authenticationKeyPair, authDoc, accelerator, mode, invocationTarget,
   documentLoader = _documentLoader
 } = {}) {
-  if(accelerator) {
-    // send operation to an accelerator for proof
-    logger.log('Sending to accelerator for proof:', accelerator);
-    operation = await attachAcceleratorProof(operation, {
-      client, authenticationKeyPair, capabilityInvocationKeyPair, accelerator,
-      authDoc, mode, logger
-    });
-  } else {
-    // send to ticket service for a proof
-    operation = await attachTicketServiceProof({client, ...operation});
-  }
+  operation = await attachAcceleratorProof(operation, {
+    client, authenticationKeyPair, capabilityInvocationKeyPair, accelerator,
+    authDoc, mode, logger
+  });
   invocationTarget = invocationTarget || did;
   const controller = capabilityInvocationKeyPair.id || signer.controller;
   // attach capability invocation proof
@@ -151,15 +144,6 @@ async function attachInvocationProof({
   });
 }
 
-async function attachTicketServiceProof({client, ...operation} = {}) {
-  const s = await client.getStatus();
-  const ticketService = s.service['urn:veresone:ticket-service'].id;
-  const result = await client.getTicketServiceProof({
-    operation, ticketService
-  });
-  return result.operation;
-}
-
 function _getOperationTarget({operation}) {
   if(operation.record) {
     return operation.record.id;
@@ -188,6 +172,5 @@ function _getRootZcap({operation}) {
 module.exports = {
   attachAcceleratorProof,
   attachInvocationProof,
-  attachProofs,
-  attachTicketServiceProof
+  attachProofs
 };


### PR DESCRIPTION
**UNFINISHED**
This PR is strictly here so that other developers may continue development on this feature in the future or comment on progress on removing the ticket service. This PR removes the ticket service logic, but does not update the accelerator to work post ticket service.


Sister PR for `veres-one` here: https://github.com/veres-one/veres-one/pull/57